### PR TITLE
Merge: "AddWordView UI 만들기"

### DIFF
--- a/KBoard/KBoard.xcodeproj/project.pbxproj
+++ b/KBoard/KBoard.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		7934B4EA2880207800CF38E9 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7934B4E92880207800CF38E9 /* View+Extension.swift */; };
 		7934B4EC2880210D00CF38E9 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7934B4EB2880210D00CF38E9 /* Constants.swift */; };
 		79FDFA9A2884E689006A03CB /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 79FDFA992884E689006A03CB /* .swiftlint.yml */; };
+		DF5056932886E55700E6F8AA /* AddWordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5056922886E55700E6F8AA /* AddWordViewController.swift */; };
+		DF50569528878B0A00E6F8AA /* WordDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF50569428878B0A00E6F8AA /* WordDetailViewController.swift */; };
+		DF5056992887A97A00E6F8AA /* WordDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5056982887A97A00E6F8AA /* WordDescriptionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +33,9 @@
 		7934B4E92880207800CF38E9 /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		7934B4EB2880210D00CF38E9 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		79FDFA992884E689006A03CB /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		DF5056922886E55700E6F8AA /* AddWordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddWordViewController.swift; sourceTree = "<group>"; };
+		DF50569428878B0A00E6F8AA /* WordDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordDetailViewController.swift; sourceTree = "<group>"; };
+		DF5056982887A97A00E6F8AA /* WordDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordDescriptionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,6 +107,8 @@
 			isa = PBXGroup;
 			children = (
 				79318CB7287E539A003B27D9 /* ViewController.swift */,
+				DF5056922886E55700E6F8AA /* AddWordViewController.swift */,
+				DF50569428878B0A00E6F8AA /* WordDetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -108,6 +116,7 @@
 		79F801FA28801C5900D3A172 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				DF5056972887A95900E6F8AA /* WordDetailUIComponent */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -138,6 +147,14 @@
 				79318CBE287E539B003B27D9 /* LaunchScreen.storyboard */,
 			);
 			path = SupportFiles;
+			sourceTree = "<group>";
+		};
+		DF5056972887A95900E6F8AA /* WordDetailUIComponent */ = {
+			isa = PBXGroup;
+			children = (
+				DF5056982887A97A00E6F8AA /* WordDescriptionView.swift */,
+			);
+			path = WordDetailUIComponent;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -236,9 +253,12 @@
 			files = (
 				7934B4EC2880210D00CF38E9 /* Constants.swift in Sources */,
 				79318CB8287E539A003B27D9 /* ViewController.swift in Sources */,
+				DF50569528878B0A00E6F8AA /* WordDetailViewController.swift in Sources */,
+				DF5056932886E55700E6F8AA /* AddWordViewController.swift in Sources */,
 				79318CB4287E539A003B27D9 /* AppDelegate.swift in Sources */,
 				7934B4EA2880207800CF38E9 /* View+Extension.swift in Sources */,
 				79318CB6287E539A003B27D9 /* SceneDelegate.swift in Sources */,
+				DF5056992887A97A00E6F8AA /* WordDescriptionView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KBoard/KBoard.xcodeproj/project.pbxproj
+++ b/KBoard/KBoard.xcodeproj/project.pbxproj
@@ -17,8 +17,6 @@
 		7934B4EC2880210D00CF38E9 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7934B4EB2880210D00CF38E9 /* Constants.swift */; };
 		79FDFA9A2884E689006A03CB /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 79FDFA992884E689006A03CB /* .swiftlint.yml */; };
 		DF5056932886E55700E6F8AA /* AddWordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5056922886E55700E6F8AA /* AddWordViewController.swift */; };
-		DF50569528878B0A00E6F8AA /* WordDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF50569428878B0A00E6F8AA /* WordDetailViewController.swift */; };
-		DF5056992887A97A00E6F8AA /* WordDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5056982887A97A00E6F8AA /* WordDescriptionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,8 +32,6 @@
 		7934B4EB2880210D00CF38E9 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		79FDFA992884E689006A03CB /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		DF5056922886E55700E6F8AA /* AddWordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddWordViewController.swift; sourceTree = "<group>"; };
-		DF50569428878B0A00E6F8AA /* WordDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordDetailViewController.swift; sourceTree = "<group>"; };
-		DF5056982887A97A00E6F8AA /* WordDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordDescriptionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,7 +104,6 @@
 			children = (
 				79318CB7287E539A003B27D9 /* ViewController.swift */,
 				DF5056922886E55700E6F8AA /* AddWordViewController.swift */,
-				DF50569428878B0A00E6F8AA /* WordDetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -116,7 +111,6 @@
 		79F801FA28801C5900D3A172 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				DF5056972887A95900E6F8AA /* WordDetailUIComponent */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -147,14 +141,6 @@
 				79318CBE287E539B003B27D9 /* LaunchScreen.storyboard */,
 			);
 			path = SupportFiles;
-			sourceTree = "<group>";
-		};
-		DF5056972887A95900E6F8AA /* WordDetailUIComponent */ = {
-			isa = PBXGroup;
-			children = (
-				DF5056982887A97A00E6F8AA /* WordDescriptionView.swift */,
-			);
-			path = WordDetailUIComponent;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -253,12 +239,10 @@
 			files = (
 				7934B4EC2880210D00CF38E9 /* Constants.swift in Sources */,
 				79318CB8287E539A003B27D9 /* ViewController.swift in Sources */,
-				DF50569528878B0A00E6F8AA /* WordDetailViewController.swift in Sources */,
 				DF5056932886E55700E6F8AA /* AddWordViewController.swift in Sources */,
 				79318CB4287E539A003B27D9 /* AppDelegate.swift in Sources */,
 				7934B4EA2880207800CF38E9 /* View+Extension.swift in Sources */,
 				79318CB6287E539A003B27D9 /* SceneDelegate.swift in Sources */,
-				DF5056992887A97A00E6F8AA /* WordDescriptionView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KBoard/KBoard/Controller/AddWordViewController.swift
+++ b/KBoard/KBoard/Controller/AddWordViewController.swift
@@ -62,8 +62,8 @@ class AddWordViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureUI() // addSubview 해주는 곳 UI 위치 배치
-        render() // backgroundColor 등 UI 색상 설정
+        render() // addSubview 해주는 곳 UI 위치 배치
+        configureUI() // backgroundColor 등 UI 색상 설정
         navigationSetting() // navigation bar에 대한 setting
         newWordTextField.delegate = self
         newWordCategoryPicker.delegate = self
@@ -72,7 +72,7 @@ class AddWordViewController: UIViewController {
         newWordDescriptionTextField.delegate = self
     }
     
-    private func configureUI() {
+    private func render() {
         view.addSubview(newWord)
         newWord.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 100, paddingLeft: 24)
         
@@ -95,8 +95,9 @@ class AddWordViewController: UIViewController {
         
     }
     
-    private func render() {
+    private func configureUI() {
         view.backgroundColor = .systemBackground
+        
     }
     
     private func navigationSetting() {

--- a/KBoard/KBoard/Controller/AddWordViewController.swift
+++ b/KBoard/KBoard/Controller/AddWordViewController.swift
@@ -1,0 +1,147 @@
+//
+//  AddWordViewController.swift
+//  KBoard
+//
+//  Created by 박성수 on 2022/07/19.
+//
+
+import UIKit
+
+class AddWordViewController: UIViewController {
+    
+    // MARK: - property
+    private let wordStack: UIStackView = {
+        let wordStack = UIStackView()
+        return wordStack
+    }()
+    
+    private let newWord: UILabel = {
+        let newWord = UILabel()
+        newWord.text = "New Word : "
+        return newWord
+    }()
+    private let newWordCategory: UILabel = {
+        let newWordCategory = UILabel()
+        newWordCategory.text = "Category : "
+        return newWordCategory
+    }()
+    private let newWordDescription: UILabel = {
+        let newWordDescription = UILabel()
+        newWordDescription.text = "Description : "
+        return newWordDescription
+    }()
+    private let newWordTextField: UITextField = {
+        let newWordTextField = UITextField()
+        newWordTextField.placeholder = "write your own word!"
+        newWordTextField.clearButtonMode = .whileEditing
+        return newWordTextField
+    }()
+    private let newWordCategoryPicker = UIPickerView()
+    private let pickerList: [String] = ["진최고", "진이대박", "나는대박", "비티에스"]
+    private let newWordCategoryTextField: UITextField = {
+        let newWordCategoryTextField = UITextField()
+        newWordCategoryTextField.text = "진최고"
+        return newWordCategoryTextField
+    }()
+    private let newWordDescriptionTextField: UITextField = {
+        let newWordDescriptionTextField = UITextField()
+        newWordDescriptionTextField.placeholder = "write some description"
+        newWordDescriptionTextField.clearButtonMode = .whileEditing
+        newWordDescriptionTextField.frame = CGRect(x: 150, y: 450, width: 150, height: 100)
+        return newWordDescriptionTextField
+    }()
+    // Toolbar REF: https://stackoverflow.com/a/37065109/19350352
+    private let toolbar: UIToolbar = {
+        let toolbar = UIToolbar()
+        toolbar.frame = CGRect(x: 0, y: 0, width: 0, height: 35)
+        let toolbarItem = UIBarButtonItem(title: "Done", style: .plain, target: nil, action: #selector(doneTapped))
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.flexibleSpace, target: nil, action: nil)
+        toolbar.setItems([flexibleSpace, toolbarItem], animated: true)
+        return toolbar
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI() // addSubview 해주는 곳 UI 위치 배치
+        navigationSetting() // navigation bar에 대한 setting
+        newWordTextField.delegate = self
+        newWordCategoryPicker.delegate = self
+        newWordCategoryPicker.dataSource = self
+        newWordDescriptionTextField.delegate = self
+    }
+    
+    private func configureUI() {
+        view.addSubview(newWord)
+        newWord.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 100, paddingLeft: 24)
+        
+        view.addSubview(newWordCategory)
+        newWordCategory.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 200, paddingLeft: 24)
+        
+        view.addSubview(newWordTextField)
+        newWordTextField.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 100, paddingLeft: 170)
+        
+        view.addSubview(newWordCategoryTextField)
+        newWordCategoryTextField.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 200, paddingLeft: 170)
+        newWordCategoryTextField.inputView = newWordCategoryPicker
+        newWordCategoryTextField.inputAccessoryView = toolbar
+        
+        view.addSubview(newWordDescription)
+        newWordDescription.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 300, paddingLeft: 24)
+        
+        view.addSubview(newWordDescriptionTextField)
+        newWordDescriptionTextField.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 300, paddingLeft: 170)
+        
+    }
+    
+    private func navigationSetting() {
+        navigationController?.navigationBar.prefersLargeTitles = true
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "cancel", style: .plain, target: self, action: #selector(dismissPage))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "save", style: .plain, target: self, action: #selector(dismissPage))
+        navigationItem.title = "Add word"
+    }
+    
+    @objc func dismissPage() {
+        // TODO: Save 하는 함수를 넣어야 한다.
+        dismiss(animated: true, completion: nil)
+    }
+    
+    @objc func doneTapped() {
+        self.view.endEditing(true)
+    }
+    
+}
+
+extension AddWordViewController: UITextFieldDelegate {
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        if newWordTextField.isEditing {
+            print("new Word --> \(textField.text ?? "")")
+            // 모델의 저장값 안에 newWordTextField.text 를 넣어줄 예정
+        } else {
+            print("new Word Description --> \(textField.text ?? "")")
+        }
+    }
+    
+}
+
+extension AddWordViewController: UIPickerViewDelegate {
+    // Picker안의 pickerList파악을 위해 delegate의 필수요건이라서 생성
+}
+
+extension AddWordViewController: UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return pickerList.count
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return pickerList[row]
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        print(pickerList[row])
+        newWordCategoryTextField.text = pickerList[row]
+    }
+}

--- a/KBoard/KBoard/Controller/AddWordViewController.swift
+++ b/KBoard/KBoard/Controller/AddWordViewController.swift
@@ -41,6 +41,7 @@ class AddWordViewController: UIViewController {
     private let newWordCategoryTextField: UITextField = {
         let newWordCategoryTextField = UITextField()
         newWordCategoryTextField.text = "진최고"
+        newWordCategoryTextField.tintColor = .clear
         return newWordCategoryTextField
     }()
     private let newWordDescriptionTextField: UITextField = {
@@ -63,10 +64,12 @@ class AddWordViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI() // addSubview 해주는 곳 UI 위치 배치
+        render() // backgroundColor 등 UI 색상 설정
         navigationSetting() // navigation bar에 대한 setting
         newWordTextField.delegate = self
         newWordCategoryPicker.delegate = self
         newWordCategoryPicker.dataSource = self
+        newWordCategoryTextField.delegate = self
         newWordDescriptionTextField.delegate = self
     }
     
@@ -91,6 +94,10 @@ class AddWordViewController: UIViewController {
         view.addSubview(newWordDescriptionTextField)
         newWordDescriptionTextField.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 300, paddingLeft: 170)
         
+    }
+    
+    private func render() {
+        view.backgroundColor = .systemBackground
     }
     
     private func navigationSetting() {
@@ -119,6 +126,13 @@ extension AddWordViewController: UITextFieldDelegate {
         } else {
             print("new Word Description --> \(textField.text ?? "")")
         }
+    }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        if newWordTextField.isEditing || newWordDescriptionTextField.isEditing {
+            return true
+        }
+        return false
     }
     
 }

--- a/KBoard/KBoard/Controller/AddWordViewController.swift
+++ b/KBoard/KBoard/Controller/AddWordViewController.swift
@@ -48,7 +48,6 @@ class AddWordViewController: UIViewController {
         let newWordDescriptionTextField = UITextField()
         newWordDescriptionTextField.placeholder = "write some description"
         newWordDescriptionTextField.clearButtonMode = .whileEditing
-        newWordDescriptionTextField.frame = CGRect(x: 150, y: 450, width: 150, height: 100)
         return newWordDescriptionTextField
     }()
     // Toolbar REF: https://stackoverflow.com/a/37065109/19350352
@@ -81,7 +80,7 @@ class AddWordViewController: UIViewController {
         newWordCategory.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 200, paddingLeft: 24)
         
         view.addSubview(newWordTextField)
-        newWordTextField.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 100, paddingLeft: 170)
+        newWordTextField.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, right: view.safeAreaLayoutGuide.rightAnchor, paddingTop: 100, paddingLeft: 170, paddingRight: 24)
         
         view.addSubview(newWordCategoryTextField)
         newWordCategoryTextField.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 200, paddingLeft: 170)
@@ -92,7 +91,7 @@ class AddWordViewController: UIViewController {
         newWordDescription.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 300, paddingLeft: 24)
         
         view.addSubview(newWordDescriptionTextField)
-        newWordDescriptionTextField.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, paddingTop: 300, paddingLeft: 170)
+        newWordDescriptionTextField.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.safeAreaLayoutGuide.leftAnchor, right: view.safeAreaLayoutGuide.rightAnchor, paddingTop: 300, paddingLeft: 170, paddingRight: 24)
         
     }
     


### PR DESCRIPTION
## 개요
내용: Add Word를 클릭시 이동하는 Full Modal의 AddWordView의 UI를 작업했습니다.

### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
  - [X] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (프로젝트 코드 변경 없음)

### 반영 브랜치
feat/4-addWordViewUI -> develop

<br/>

## 작업사항 
### 작업 사항
AddWordView 의 UI

<img src = "https://user-images.githubusercontent.com/72736657/180139490-6a6d9dbd-9bc5-4290-9f78-85a74404e0dd.png" width = "250" />

<br/>

## 그외
### 리뷰 포인트 
- 프로퍼티와 그 선언된 값의 모디파이어들이 적당한 위치에 선언되어 있는지?(ex. 이 친구는 viewDidLoad에 있으면 안될 것 같아요)
- 주석이 자신의 역할을 잘 하고 있는지, 필요한 주석이 맞을지
- 변수 네이밍이 적절한지
- 오토레이아웃 설정시 더 좋은 방법

### 진행 예정 사항
- [ ] AddWordViewController안의 UI컴포넌트들을 View 파일을 만들어 옮길 예정입니다.
- [ ] UILabel과 UITextfield의 위치가 지금은 하드코딩이지만, Stack으로 만들어 관리할 예정입니다.

## Checklist

- [X] 올바른 branch에 merge 하시는 건가요?
- [X] coding convention 맞추었나요?
- [X] Are there any changes not related to PR?
