### PR TITLE
Merge: "WordDetailView 상단Cell UI 만들기"

### DIFF
--- a/KBoard/KBoard.xcodeproj/project.pbxproj
+++ b/KBoard/KBoard.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		7934B4EA2880207800CF38E9 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7934B4E92880207800CF38E9 /* View+Extension.swift */; };
 		7934B4EC2880210D00CF38E9 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7934B4EB2880210D00CF38E9 /* Constants.swift */; };
 		79FDFA9A2884E689006A03CB /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 79FDFA992884E689006A03CB /* .swiftlint.yml */; };
+		DF50569B288924EA00E6F8AA /* WordDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF50569A288924EA00E6F8AA /* WordDetailViewController.swift */; };
+		DF50569D288924F600E6F8AA /* WordDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF50569C288924F600E6F8AA /* WordDescriptionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +32,8 @@
 		7934B4E92880207800CF38E9 /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		7934B4EB2880210D00CF38E9 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		79FDFA992884E689006A03CB /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		DF50569A288924EA00E6F8AA /* WordDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordDetailViewController.swift; sourceTree = "<group>"; };
+		DF50569C288924F600E6F8AA /* WordDescriptionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordDescriptionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,6 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				79318CB7287E539A003B27D9 /* ViewController.swift */,
+				DF50569A288924EA00E6F8AA /* WordDetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -108,6 +113,7 @@
 		79F801FA28801C5900D3A172 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				DF50569E2889252100E6F8AA /* WordDetailViewUIComponent */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -138,6 +144,14 @@
 				79318CBE287E539B003B27D9 /* LaunchScreen.storyboard */,
 			);
 			path = SupportFiles;
+			sourceTree = "<group>";
+		};
+		DF50569E2889252100E6F8AA /* WordDetailViewUIComponent */ = {
+			isa = PBXGroup;
+			children = (
+				DF50569C288924F600E6F8AA /* WordDescriptionView.swift */,
+			);
+			path = WordDetailViewUIComponent;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -239,6 +253,8 @@
 				79318CB4287E539A003B27D9 /* AppDelegate.swift in Sources */,
 				7934B4EA2880207800CF38E9 /* View+Extension.swift in Sources */,
 				79318CB6287E539A003B27D9 /* SceneDelegate.swift in Sources */,
+				DF50569D288924F600E6F8AA /* WordDescriptionView.swift in Sources */,
+				DF50569B288924EA00E6F8AA /* WordDetailViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -385,7 +401,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = H5PD3P95F5;
+				DEVELOPMENT_TEAM = DF85MB57QP;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KBoard/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -413,7 +429,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = H5PD3P95F5;
+				DEVELOPMENT_TEAM = DF85MB57QP;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KBoard/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/KBoard/KBoard/Controller/WordDetailViewController.swift
+++ b/KBoard/KBoard/Controller/WordDetailViewController.swift
@@ -1,0 +1,32 @@
+//
+//  WordDetailViewController.swift
+//  KBoard
+//
+//  Created by 박성수 on 2022/07/20.
+//
+
+import UIKit
+
+class WordDetailViewController: UIViewController {
+    
+    private let wordDescriptionView = WordDescriptionView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        
+    }
+    
+    private func configureUI() {
+        view.backgroundColor = .white
+        view.addSubview(wordDescriptionView)
+        wordDescriptionView.anchor(top: view.safeAreaLayoutGuide.topAnchor, paddingTop: 20, width: UIScreen.main.bounds.width - 48)
+        wordDescriptionView.centerX(inView: view)
+        
+        wordDescriptionView.layer.masksToBounds = false
+        wordDescriptionView.layer.shadowRadius = 5
+        wordDescriptionView.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
+        wordDescriptionView.layer.shadowOpacity = 0.2
+    }
+        
+}

--- a/KBoard/KBoard/Controller/WordDetailViewController.swift
+++ b/KBoard/KBoard/Controller/WordDetailViewController.swift
@@ -13,16 +13,20 @@ class WordDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureUI()
+        render() // layout 배치
+        configureUI() // background 색상등 추가 설정
+        
+    }
+    
+    private func render() {
+        view.addSubview(wordDescriptionView)
+        wordDescriptionView.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
+        wordDescriptionView.centerX(inView: view)
         
     }
     
     private func configureUI() {
         view.backgroundColor = .systemBackground
-        view.addSubview(wordDescriptionView)
-        wordDescriptionView.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
-        wordDescriptionView.centerX(inView: view)
-        
         wordDescriptionView.layer.masksToBounds = false
         wordDescriptionView.layer.shadowRadius = 5
         wordDescriptionView.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)

--- a/KBoard/KBoard/Controller/WordDetailViewController.swift
+++ b/KBoard/KBoard/Controller/WordDetailViewController.swift
@@ -27,10 +27,6 @@ class WordDetailViewController: UIViewController {
     
     private func configureUI() {
         view.backgroundColor = .systemBackground
-        wordDescriptionView.layer.masksToBounds = false
-        wordDescriptionView.layer.shadowRadius = 5
-        wordDescriptionView.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
-        wordDescriptionView.layer.shadowOpacity = 0.2
         
     }
 

--- a/KBoard/KBoard/Controller/WordDetailViewController.swift
+++ b/KBoard/KBoard/Controller/WordDetailViewController.swift
@@ -20,7 +20,7 @@ class WordDetailViewController: UIViewController {
     
     private func render() {
         view.addSubview(wordDescriptionView)
-        wordDescriptionView.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
+        wordDescriptionView.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 0, paddingLeft: 16, paddingRight: 16)
         wordDescriptionView.centerX(inView: view)
         
     }

--- a/KBoard/KBoard/Controller/WordDetailViewController.swift
+++ b/KBoard/KBoard/Controller/WordDetailViewController.swift
@@ -20,13 +20,14 @@ class WordDetailViewController: UIViewController {
     private func configureUI() {
         view.backgroundColor = .systemBackground
         view.addSubview(wordDescriptionView)
-        wordDescriptionView.anchor(top: view.safeAreaLayoutGuide.topAnchor, paddingTop: 20, width: UIScreen.main.bounds.width - 48)
+        wordDescriptionView.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
         wordDescriptionView.centerX(inView: view)
         
         wordDescriptionView.layer.masksToBounds = false
         wordDescriptionView.layer.shadowRadius = 5
         wordDescriptionView.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
         wordDescriptionView.layer.shadowOpacity = 0.2
-    }
         
+    }
+
 }

--- a/KBoard/KBoard/Controller/WordDetailViewController.swift
+++ b/KBoard/KBoard/Controller/WordDetailViewController.swift
@@ -18,7 +18,7 @@ class WordDetailViewController: UIViewController {
     }
     
     private func configureUI() {
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         view.addSubview(wordDescriptionView)
         wordDescriptionView.anchor(top: view.safeAreaLayoutGuide.topAnchor, paddingTop: 20, width: UIScreen.main.bounds.width - 48)
         wordDescriptionView.centerX(inView: view)

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/WordDescriptionView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/WordDescriptionView.swift
@@ -1,0 +1,90 @@
+//
+//  WordDescriptionView.swift
+//  KBoard
+//
+//  Created by 박성수 on 2022/07/20.
+//
+
+import UIKit
+
+class WordDescriptionView: UIView {
+
+    // MARK: - property
+    private let wordKorean: UILabel = {
+        let wordKorean = UILabel()
+        wordKorean.text = "뮤직쇼"
+        wordKorean.font = UIFont.boldSystemFont(ofSize: 28)
+        return wordKorean
+    }()
+    
+    private let wordEnglish: UILabel = {
+        let wordEnglish = UILabel()
+        wordEnglish.text = "Music Show"
+        wordEnglish.font = wordEnglish.font.withSize(18)
+        return wordEnglish
+    }()
+    
+    private let starButton: UIButton = {
+        let starButton = UIButton()
+        starButton.setImage(UIImage(systemName: "star"), for: .normal)
+        starButton.tintColor = .systemYellow
+        starButton.addTarget(self, action: #selector(starTapped), for: .touchUpInside)
+        return starButton
+    }()
+    
+    private let wordDescription: UILabel = {
+        let wordDescription = UILabel()
+        wordDescription.text = "Music Show means f let artworkf = album.asdfasdfs asfasdfpoiupopwlekjsadfdMusic Show means f let artworkf = album.asdfasdfs asfasdfp"
+        wordDescription.numberOfLines = 0
+        return wordDescription
+    }()
+    
+    private let seperator: UIView = {
+        let seperator = UIView()
+        seperator.frame = CGRect(origin: .zero, size: .init())
+        seperator.backgroundColor = .black
+        return seperator
+    }()
+    
+    // MARK: - function
+    @objc func starTapped() {
+        starButton.setImage(UIImage(systemName: (starButton.currentImage == UIImage(systemName: "star")) ?  "star.fill" :  "star"), for: .normal)
+    }
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func render() {
+        self.addSubview(wordKorean)
+        wordKorean.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 30, paddingLeft: 20)
+ 
+        self.addSubview(wordEnglish)
+        wordEnglish.anchor(top: wordKorean.bottomAnchor, left: self.leftAnchor, paddingTop: 3, paddingLeft: 20)
+        
+        self.addSubview(starButton)
+        starButton.anchor(top: self.topAnchor, right: self.rightAnchor, paddingTop: 50, paddingRight: 30, width: 25, height: 25)
+        
+        self.addSubview(seperator)
+        seperator.anchor(top: wordEnglish.bottomAnchor, left: self.leftAnchor, paddingTop: 20, paddingLeft: 20, height: 1)
+        seperator.centerX(inView: self)
+        
+        self.addSubview(wordDescription)
+        wordDescription.anchor(top: wordEnglish.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 40, paddingLeft: 20, paddingBottom: 20, paddingRight: 20)
+        
+    }
+    
+    private func configureUI() {
+        self.backgroundColor = .white
+        self.layer.cornerRadius = 15
+        
+    }
+
+}

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/WordDescriptionView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/WordDescriptionView.swift
@@ -84,6 +84,10 @@ class WordDescriptionView: UIView {
     private func configureUI() {
         self.backgroundColor = .systemBackground
         self.layer.cornerRadius = 15
+        self.layer.masksToBounds = false
+        self.layer.shadowRadius = 5
+        self.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
+        self.layer.shadowOpacity = 0.2
         
     }
 

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/WordDescriptionView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/WordDescriptionView.swift
@@ -70,14 +70,14 @@ class WordDescriptionView: UIView {
         wordEnglish.anchor(top: wordKorean.bottomAnchor, left: self.leftAnchor, paddingTop: 3, paddingLeft: 20)
         
         self.addSubview(starButton)
-        starButton.anchor(top: self.topAnchor, right: self.rightAnchor, paddingTop: 50, paddingRight: 30, width: 25, height: 25)
+        starButton.anchor(top: self.topAnchor, right: self.rightAnchor, paddingTop: 50, paddingRight: 40)
         
         self.addSubview(seperator)
         seperator.anchor(top: wordEnglish.bottomAnchor, left: self.leftAnchor, paddingTop: 20, paddingLeft: 20, height: 1)
         seperator.centerX(inView: self)
         
         self.addSubview(wordDescription)
-        wordDescription.anchor(top: wordEnglish.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 40, paddingLeft: 20, paddingBottom: 20, paddingRight: 20)
+        wordDescription.anchor(top: seperator.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingBottom: 20, paddingRight: 20)
         
     }
     

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/WordDescriptionView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/WordDescriptionView.swift
@@ -82,7 +82,7 @@ class WordDescriptionView: UIView {
     }
     
     private func configureUI() {
-        self.backgroundColor = .white
+        self.backgroundColor = .systemBackground
         self.layer.cornerRadius = 15
         
     }


### PR DESCRIPTION
WordDetailView의 상단 Cell UI를 구현

Resolves: #7
TODO: 1. seperator 역할을 하는 UIVIew가 조금 부자연스러운 느낌이라, 개선하고 싶음 2. configureUI함수가 영향을 미치는 범위를 정확히 하고 싶음

### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
  - [X] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (프로젝트 코드 변경 없음)

### 반영 브랜치
feat/7-wordDetailUpperCardUI -> develop

<br/>

## 작업사항 
### 작업 사항
- WordDetailView 진입시, 가장 상단에 위치하는 단어의 한글과 영어 및 영어로 이루어진 description이 존재하는 Cell을 만들었습니다.
- 한글로 이루어진 단어와 영어 오른편에는 즐겨찾기 기능을 위한 별표 모양 button이 있습니다. touch시 토글됩니다.

### 테스트 결과 (스크린샷, GIF)
<img width="250" alt="스샷" src="https://user-images.githubusercontent.com/72736657/180249263-fa142dbe-7f03-4e9b-aa6f-d7707f50d3bb.png">

<br/>

## 그외
### 리뷰 포인트 
- `WordDetailViewController.swift`와 `WordDescriptionView.swift`에서 카드뷰의 layout, background, cornerRadius 등의 값을 주기위해 두개의 파일에서 모두 `configureUI()`가 있는데, ViewController에서 카드뷰의 설정값들을 주어야 할지, View파일에서 주어야 할지 혹은 어떻게 나누어 각각 주어야 할지 잘 모르겠습니다. -> ViewController에서 떼어와서 WordDescriptionView에서 configureUI 전체를 해주게 바꾸었습니다.
- 카드뷰의 후면에 shadow값을 주기위해 `WordDescriptionView` 객체에 shadow를 주면, `WordDescriptionView`안의 모든 UI 객체들에게 shadow값이 적용되어, `WordDescriptionView`의 backgroundColor를 white로 shadow가 안보이도록 해둔 상태입니다. 모든 UI 객체에 shadow를 주지 않고, 카드뷰에만 적용시키는 방법을 알려주세요!

### 진행 예정 사항
- [x] 최우선 순위로는 WordDetailView의 중간 카드뷰와 하단 카드뷰를 구현할 예정입니다. #11 
- [X] Dark, Light Mode 간의 전환시, 텍스트와 뒷배경 색 대응이 안되기 때문에, 모드에 대해서도 이야기를 해봐야 할 것 같습니다. -> .systemBackground로 해결해둔 상태입니다.

## Checklist

- [X] 올바른 branch에 merge 하시는 건가요?
- [X] coding convention 맞추었나요?
- [X] Are there any changes not related to PR?
