### PR TITLE
Merge: WordDetail usage related UI 만들기

### DIFF
--- a/KBoard/KBoard.xcodeproj/project.pbxproj
+++ b/KBoard/KBoard.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		DF50569D288924F600E6F8AA /* WordDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF50569C288924F600E6F8AA /* WordDescriptionView.swift */; };
 		DF5056A0288A9A1900E6F8AA /* WordUsageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF50569F288A9A1900E6F8AA /* WordUsageView.swift */; };
 		DF5056A2288B126300E6F8AA /* UsageContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5056A1288B126300E6F8AA /* UsageContext.swift */; };
+		DF5056A4288C34D600E6F8AA /* RelatedWordsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5056A3288C34D600E6F8AA /* RelatedWordsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +39,7 @@
 		DF50569C288924F600E6F8AA /* WordDescriptionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordDescriptionView.swift; sourceTree = "<group>"; };
 		DF50569F288A9A1900E6F8AA /* WordUsageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordUsageView.swift; sourceTree = "<group>"; };
 		DF5056A1288B126300E6F8AA /* UsageContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageContext.swift; sourceTree = "<group>"; };
+		DF5056A3288C34D600E6F8AA /* RelatedWordsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelatedWordsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -156,6 +158,7 @@
 				DF50569C288924F600E6F8AA /* WordDescriptionView.swift */,
 				DF50569F288A9A1900E6F8AA /* WordUsageView.swift */,
 				DF5056A1288B126300E6F8AA /* UsageContext.swift */,
+				DF5056A3288C34D600E6F8AA /* RelatedWordsView.swift */,
 			);
 			path = WordDetailViewUIComponent;
 			sourceTree = "<group>";
@@ -260,6 +263,7 @@
 				DF5056A2288B126300E6F8AA /* UsageContext.swift in Sources */,
 				79318CB4287E539A003B27D9 /* AppDelegate.swift in Sources */,
 				7934B4EA2880207800CF38E9 /* View+Extension.swift in Sources */,
+				DF5056A4288C34D600E6F8AA /* RelatedWordsView.swift in Sources */,
 				79318CB6287E539A003B27D9 /* SceneDelegate.swift in Sources */,
 				DF50569D288924F600E6F8AA /* WordDescriptionView.swift in Sources */,
 				DF50569B288924EA00E6F8AA /* WordDetailViewController.swift in Sources */,

--- a/KBoard/KBoard.xcodeproj/project.pbxproj
+++ b/KBoard/KBoard.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		DF50569B288924EA00E6F8AA /* WordDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF50569A288924EA00E6F8AA /* WordDetailViewController.swift */; };
 		DF50569D288924F600E6F8AA /* WordDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF50569C288924F600E6F8AA /* WordDescriptionView.swift */; };
 		DF5056A0288A9A1900E6F8AA /* WordUsageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF50569F288A9A1900E6F8AA /* WordUsageView.swift */; };
-		DF5056A2288B126300E6F8AA /* UsageContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5056A1288B126300E6F8AA /* UsageContext.swift */; };
+		DF5056A2288B126300E6F8AA /* UsageContextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5056A1288B126300E6F8AA /* UsageContextView.swift */; };
 		DF5056A4288C34D600E6F8AA /* RelatedWordsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5056A3288C34D600E6F8AA /* RelatedWordsView.swift */; };
 /* End PBXBuildFile section */
 
@@ -38,7 +38,7 @@
 		DF50569A288924EA00E6F8AA /* WordDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordDetailViewController.swift; sourceTree = "<group>"; };
 		DF50569C288924F600E6F8AA /* WordDescriptionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordDescriptionView.swift; sourceTree = "<group>"; };
 		DF50569F288A9A1900E6F8AA /* WordUsageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordUsageView.swift; sourceTree = "<group>"; };
-		DF5056A1288B126300E6F8AA /* UsageContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageContext.swift; sourceTree = "<group>"; };
+		DF5056A1288B126300E6F8AA /* UsageContextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageContextView.swift; sourceTree = "<group>"; };
 		DF5056A3288C34D600E6F8AA /* RelatedWordsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelatedWordsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -157,7 +157,7 @@
 			children = (
 				DF50569C288924F600E6F8AA /* WordDescriptionView.swift */,
 				DF50569F288A9A1900E6F8AA /* WordUsageView.swift */,
-				DF5056A1288B126300E6F8AA /* UsageContext.swift */,
+				DF5056A1288B126300E6F8AA /* UsageContextView.swift */,
 				DF5056A3288C34D600E6F8AA /* RelatedWordsView.swift */,
 			);
 			path = WordDetailViewUIComponent;
@@ -260,7 +260,7 @@
 				7934B4EC2880210D00CF38E9 /* Constants.swift in Sources */,
 				79318CB8287E539A003B27D9 /* ViewController.swift in Sources */,
 				DF5056A0288A9A1900E6F8AA /* WordUsageView.swift in Sources */,
-				DF5056A2288B126300E6F8AA /* UsageContext.swift in Sources */,
+				DF5056A2288B126300E6F8AA /* UsageContextView.swift in Sources */,
 				79318CB4287E539A003B27D9 /* AppDelegate.swift in Sources */,
 				7934B4EA2880207800CF38E9 /* View+Extension.swift in Sources */,
 				DF5056A4288C34D600E6F8AA /* RelatedWordsView.swift in Sources */,

--- a/KBoard/KBoard.xcodeproj/project.pbxproj
+++ b/KBoard/KBoard.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		79FDFA9A2884E689006A03CB /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 79FDFA992884E689006A03CB /* .swiftlint.yml */; };
 		DF50569B288924EA00E6F8AA /* WordDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF50569A288924EA00E6F8AA /* WordDetailViewController.swift */; };
 		DF50569D288924F600E6F8AA /* WordDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF50569C288924F600E6F8AA /* WordDescriptionView.swift */; };
+		DF5056A0288A9A1900E6F8AA /* WordUsageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF50569F288A9A1900E6F8AA /* WordUsageView.swift */; };
+		DF5056A2288B126300E6F8AA /* UsageContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5056A1288B126300E6F8AA /* UsageContext.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +36,8 @@
 		79FDFA992884E689006A03CB /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		DF50569A288924EA00E6F8AA /* WordDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordDetailViewController.swift; sourceTree = "<group>"; };
 		DF50569C288924F600E6F8AA /* WordDescriptionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordDescriptionView.swift; sourceTree = "<group>"; };
+		DF50569F288A9A1900E6F8AA /* WordUsageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordUsageView.swift; sourceTree = "<group>"; };
+		DF5056A1288B126300E6F8AA /* UsageContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageContext.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -150,6 +154,8 @@
 			isa = PBXGroup;
 			children = (
 				DF50569C288924F600E6F8AA /* WordDescriptionView.swift */,
+				DF50569F288A9A1900E6F8AA /* WordUsageView.swift */,
+				DF5056A1288B126300E6F8AA /* UsageContext.swift */,
 			);
 			path = WordDetailViewUIComponent;
 			sourceTree = "<group>";
@@ -250,6 +256,8 @@
 			files = (
 				7934B4EC2880210D00CF38E9 /* Constants.swift in Sources */,
 				79318CB8287E539A003B27D9 /* ViewController.swift in Sources */,
+				DF5056A0288A9A1900E6F8AA /* WordUsageView.swift in Sources */,
+				DF5056A2288B126300E6F8AA /* UsageContext.swift in Sources */,
 				79318CB4287E539A003B27D9 /* AppDelegate.swift in Sources */,
 				7934B4EA2880207800CF38E9 /* View+Extension.swift in Sources */,
 				79318CB6287E539A003B27D9 /* SceneDelegate.swift in Sources */,

--- a/KBoard/KBoard/Controller/WordDetailViewController.swift
+++ b/KBoard/KBoard/Controller/WordDetailViewController.swift
@@ -23,7 +23,6 @@ class WordDetailViewController: UIViewController {
     private func render() {
         view.addSubview(wordDescriptionView)
         wordDescriptionView.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
-        wordDescriptionView.centerX(inView: view)
         
         view.addSubview(wordUsageView)
         wordUsageView.anchor(top: wordDescriptionView.bottomAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)

--- a/KBoard/KBoard/Controller/WordDetailViewController.swift
+++ b/KBoard/KBoard/Controller/WordDetailViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 class WordDetailViewController: UIViewController {
     
     private let wordDescriptionView = WordDescriptionView()
+    private let wordUsageView = WordUsageView()
+    private let relatedWordsView = RelatedWordsView()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -22,6 +24,12 @@ class WordDetailViewController: UIViewController {
         view.addSubview(wordDescriptionView)
         wordDescriptionView.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
         wordDescriptionView.centerX(inView: view)
+        
+        view.addSubview(wordUsageView)
+        wordUsageView.anchor(top: wordDescriptionView.bottomAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
+        
+        view.addSubview(relatedWordsView)
+        relatedWordsView.anchor(top: wordUsageView.bottomAnchor, left: view.leftAnchor, right: view.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
         
     }
     

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/RelatedWordsView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/RelatedWordsView.swift
@@ -19,7 +19,7 @@ class RelatedWordsView: UIView {
     
     private let relatedWordButton: UIButton = {
         let relatedWordButton = UIButton()
-        relatedWordButton.setTitle("Inki-Gayo", for: .normal)
+        relatedWordButton.setTitle("Inki-Gayoasdfasdfsdfasdfasdfasdfasdfasd", for: .normal)
         relatedWordButton.titleLabel?.font = .boldSystemFont(ofSize: 17)
         relatedWordButton.tintColor = .white
         relatedWordButton.backgroundColor = .systemBlue
@@ -44,7 +44,7 @@ class RelatedWordsView: UIView {
         relatedWordsLabel.anchor(top: self.topAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
         
         self.addSubview(relatedWordButton)
-        relatedWordButton.anchor(top: relatedWordsLabel.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, paddingTop: 10, paddingLeft: 20, paddingBottom: 20)
+        relatedWordButton.anchor(top: relatedWordsLabel.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 10, paddingLeft: 20, paddingBottom: 20, paddingRight: 20)
         
     }
     

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/RelatedWordsView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/RelatedWordsView.swift
@@ -1,0 +1,60 @@
+//
+//  RelatedWordsView.swift
+//  KBoard
+//
+//  Created by 박성수 on 2022/07/23.
+//
+
+import UIKit
+
+class RelatedWordsView: UIView {
+    
+    // MARK: - property
+    private let relatedWordsLabel: UILabel = {
+        let relatedWordsLabel = UILabel()
+        relatedWordsLabel.text = "Related Words"
+        relatedWordsLabel.font = .boldSystemFont(ofSize: 16)
+        return relatedWordsLabel
+    }()
+    
+    private let relatedWordButton: UIButton = {
+        let relatedWordButton = UIButton()
+        relatedWordButton.setTitle("Inki-Gayo", for: .normal)
+        relatedWordButton.titleLabel?.font = .boldSystemFont(ofSize: 17)
+        relatedWordButton.tintColor = .white
+        relatedWordButton.backgroundColor = .systemBlue
+        relatedWordButton.layer.cornerRadius = 10
+        relatedWordButton.contentEdgeInsets = UIEdgeInsets(top: 8, left: 15, bottom: 8, right: 15)
+        return relatedWordButton
+    }()
+
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func render() {
+        self.addSubview(relatedWordsLabel)
+        relatedWordsLabel.anchor(top: self.topAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
+        
+        self.addSubview(relatedWordButton)
+        relatedWordButton.anchor(top: relatedWordsLabel.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, paddingTop: 10, paddingLeft: 20, paddingBottom: 20)
+        
+    }
+    
+    private func configureUI() {
+        self.backgroundColor = .systemBackground
+        self.layer.cornerRadius = 15
+        self.layer.masksToBounds = false
+        self.layer.shadowRadius = 5
+        self.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
+        self.layer.shadowOpacity = 0.2
+    }
+    
+}

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/RelatedWordsView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/RelatedWordsView.swift
@@ -16,23 +16,58 @@ class RelatedWordsView: UIView {
         relatedWordsLabel.font = .boldSystemFont(ofSize: 16)
         return relatedWordsLabel
     }()
-    
-    private let relatedWordButton: UIButton = {
-        let relatedWordButton = UIButton()
-        relatedWordButton.setTitle("Inki-Gayoasdfasdfsdfasdfasdfasdfasdfasd", for: .normal)
-        relatedWordButton.titleLabel?.font = .boldSystemFont(ofSize: 17)
-        relatedWordButton.tintColor = .white
-        relatedWordButton.backgroundColor = .systemBlue
-        relatedWordButton.layer.cornerRadius = 10
-        relatedWordButton.contentEdgeInsets = UIEdgeInsets(top: 8, left: 15, bottom: 8, right: 15)
-        return relatedWordButton
+    private lazy var relatedLabel: UILabel = {
+        let relatedLabel = UILabel()
+        relatedLabel.text = "Umak Bang song"
+        relatedLabel.frame.size.width = relatedLabel.intrinsicContentSize.width + tagPadding
+        relatedLabel.frame.size.height = tagHeight
+        return relatedLabel
     }()
-
+    private lazy var relatedLabel2: UILabel = {
+        let relatedLabel2 = UILabel()
+        relatedLabel2.text = "sa geon nok hwa"
+        relatedLabel2.frame.size.width = relatedLabel2.intrinsicContentSize.width + tagPadding
+        relatedLabel2.frame.size.height = tagHeight
+        return relatedLabel2
+    }()
+    private lazy var relatedLabel3: UILabel = {
+        let relatedLabel3 = UILabel()
+        relatedLabel3.text = "ASAP"
+        relatedLabel3.frame.size.width = relatedLabel3.intrinsicContentSize.width + tagPadding
+        relatedLabel3.frame.size.height = tagHeight
+        return relatedLabel3
+    }()
+    private lazy var relatedLabel4: UILabel = {
+        let relatedLabel4 = UILabel()
+        relatedLabel4.text = "Chut bangsong"
+        relatedLabel4.frame.size.width = relatedLabel4.intrinsicContentSize.width + tagPadding
+        relatedLabel4.frame.size.height = tagHeight
+        return relatedLabel4
+    }()
+    private lazy var relatedLabel5: UILabel = {
+        let relatedLabel5 = UILabel()
+        relatedLabel5.text = "sadfassdfasfsasfdasdasfasdfdfa"
+        relatedLabel5.frame.size.width = relatedLabel5.intrinsicContentSize.width + tagPadding
+        relatedLabel5.frame.size.height = tagHeight
+        return relatedLabel5
+    }()
+    private lazy var containerView: UIView = {
+        let containerView = UIView()
+        return containerView
+    }()
+    private lazy var relatedWordArray: [UILabel] = [relatedLabel, relatedLabel2, relatedLabel3, relatedLabel4, relatedLabel5]
+    private let tagHeight: CGFloat = 30
+    private let tagPadding: CGFloat = 16
+    private let tagSpacingX: CGFloat = 8
+    private let tagSpacingY: CGFloat = 8
+    
     // MARK: - init
     override init(frame: CGRect) {
         super.init(frame: frame)
         render()
         configureUI()
+        displayTagLabels()
+        
     }
     
     required init?(coder: NSCoder) {
@@ -43,9 +78,16 @@ class RelatedWordsView: UIView {
         self.addSubview(relatedWordsLabel)
         relatedWordsLabel.anchor(top: self.topAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
         
-        self.addSubview(relatedWordButton)
-        relatedWordButton.anchor(top: relatedWordsLabel.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 10, paddingLeft: 20, paddingBottom: 20, paddingRight: 20)
+        self.addSubview(containerView)
+        containerView.anchor(left: self.leftAnchor, right: self.rightAnchor, paddingLeft: 20, paddingRight: 20)
         
+        relatedWordArray.forEach { word in
+            containerView.addSubview(word)
+        }
+        containerView.anchor(top: relatedWordsLabel.bottomAnchor, paddingTop: 15, width: self.bounds.width, height: self.bounds.height)
+        if let last = relatedWordArray.last {
+            last.anchor(bottom: self.bottomAnchor, paddingBottom: 20)
+        }
     }
     
     private func configureUI() {
@@ -55,6 +97,20 @@ class RelatedWordsView: UIView {
         self.layer.shadowRadius = 5
         self.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
         self.layer.shadowOpacity = 0.2
+    }
+    
+    // REF: https://stackoverflow.com/a/60588546/19350352
+    func displayTagLabels() {
+        var currentOriginX: CGFloat = 0
+        var currentOriginY: CGFloat = 0
+        relatedWordArray.forEach { label in
+            if currentOriginX + label.bounds.width > UIScreen.main.bounds.width - 32 {
+                currentOriginX = 0
+                currentOriginY += tagHeight + tagSpacingY
+            }
+            label.anchor(top: containerView.topAnchor, left: containerView.leftAnchor, paddingTop: currentOriginY, paddingLeft: currentOriginX)
+            currentOriginX += label.bounds.width + tagSpacingX
+        }
     }
     
 }

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/UsageContext.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/UsageContext.swift
@@ -1,0 +1,48 @@
+//
+//  UsageContext.swift
+//  KBoard
+//
+//  Created by 박성수 on 2022/07/23.
+//
+
+import UIKit
+
+// MARK: UsageContext는 Korean, English Usage가 들어온다 가정하고 만든 class
+class UsageContext: UIView {
+    
+    // MARK: - property
+    private let usageKorean: UILabel = {
+       let usageKorean = UILabel()
+        usageKorean.text = "저번 주 뮤직쇼 봤어?"
+        usageKorean.font = usageKorean.font.withSize(16)
+        usageKorean.numberOfLines = 0
+        return usageKorean
+    }()
+    
+    private let usageEnglish: UILabel = {
+       let usageEnglish = UILabel()
+        usageEnglish.text = "Did you see Music show last week?"
+        usageEnglish.font = usageEnglish.font.withSize(16)
+        usageEnglish.numberOfLines = 0
+        return usageEnglish
+    }()
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func render() {
+        self.addSubview(usageKorean)
+        usageKorean.anchor(top: self.topAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 0, paddingLeft: 0, paddingRight: 0)
+        
+        self.addSubview(usageEnglish)
+        usageEnglish.anchor(top: usageKorean.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 3, paddingLeft: 0, paddingBottom: 0, paddingRight: 0)
+    }
+    
+}

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/UsageContextView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/UsageContextView.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 // MARK: UsageContext는 Korean, English Usage가 들어온다 가정하고 만든 class
-class UsageContext: UIView {
+class UsageContextView: UIView {
     
     // MARK: - property
     private let usageKorean: UILabel = {

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/WordUsageView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/WordUsageView.swift
@@ -16,6 +16,14 @@ class WordUsageView: UIView {
         usageLabel.font = .systemFont(ofSize: 16, weight: .bold)
         return usageLabel
     }()
+    private let usageStack: UIStackView = {
+        let usageStack = UIStackView()
+        usageStack.axis = .vertical
+        usageStack.distribution = .fillEqually
+        usageStack.alignment = .leading
+        usageStack.spacing = 10
+        return usageStack
+    }()
     private var usageArray: [UsageContext] = []
     private var tempUsage: UsageContext?
     
@@ -23,8 +31,7 @@ class WordUsageView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         dataSetting()
-        defaultRender()
-        bottomAnchorRender()
+        render()
         configureUI()
     }
     
@@ -37,35 +44,15 @@ class WordUsageView: UIView {
         let usageExample = UsageContext()
         let usageExample2 = UsageContext()
         usageArray = [usageExample, usageExample2]
-    }
-    
-    private func defaultRender() {
-        self.addSubview(usageLabel)
-        usageLabel.anchor(top: self.topAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
-        if !usageArray.isEmpty {
-            for usage in usageArray {
-                self.addSubview(usage)
-                if usage == usageArray.first {
-                    usage.anchor(top: usageLabel.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 15, paddingLeft: 20, paddingRight: 20)
-                } else {
-                    usage.anchor(top: self.tempUsage!.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 15, paddingLeft: 20, paddingRight: 20)
-                }
-                self.tempUsage = usage
-            }
-        } else {
-            usageLabel.anchor(bottom: self.bottomAnchor, paddingBottom: 20)
-        }
-    }
-    
-    private func bottomAnchorRender() {
+        usageStack.addArrangedSubview(usageLabel)
         for usage in usageArray {
-            self.addSubview(usage)
-            if (usage == usageArray.first && usage == usageArray.last) || usage == usageArray.last {
-                // Usage 개수가 1개인 경우 Start Point OR 해당 context가 배열의 마지막 context일때
-                usage.anchor(bottom: self.bottomAnchor, paddingBottom: 20)
-            }
-            self.tempUsage = usage
+            usageStack.addArrangedSubview(usage)
         }
+    }
+    
+    private func render() {
+        self.addSubview(usageStack)
+        usageStack.anchor(top: self.topAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 10, paddingLeft: 20, paddingBottom: 20, paddingRight: 20)
     }
     
     private func configureUI() {

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/WordUsageView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/WordUsageView.swift
@@ -23,7 +23,8 @@ class WordUsageView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         dataSetting()
-        render()
+        defaultRender()
+        bottomAnchorRender()
         configureUI()
     }
     
@@ -35,31 +36,35 @@ class WordUsageView: UIView {
         // MARK: 아래 두 데이터는 뷰를 보기위해 가상의 데이터를 만들어주었다. 추후 데이터 세팅과 불러오는데 쓰일 예정
         let usageExample = UsageContext()
         let usageExample2 = UsageContext()
-        self.usageArray = [usageExample, usageExample2]
+        usageArray = [usageExample, usageExample2]
     }
     
-    private func render() {
+    private func defaultRender() {
         self.addSubview(usageLabel)
-        if usageArray.isEmpty { // Usage 개수가 0 인 case
-            usageLabel.anchor(top: self.topAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingBottom: 20, paddingRight: 20)
-        } else {
-            usageLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 20, paddingLeft: 20)
+        usageLabel.anchor(top: self.topAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingRight: 20)
+        if !usageArray.isEmpty {
             for usage in usageArray {
                 self.addSubview(usage)
-                if usage == usageArray.first && usage != usageArray.last { // Usage 개수가 1개가 아닌 경우 Start Point
-                    usage.anchor(top: usageLabel.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 10, paddingLeft: 20, paddingRight: 20)
-                    tempUsage = usage
-                } else if usage == usageArray.first && usage == usageArray.last { // Usage 개수가 1개인 경우 Start Point
-                    usage.anchor(top: usageLabel.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 15, paddingLeft: 20, paddingBottom: 20, paddingRight: 20)
-                } else if usage == usageArray.last { // Usage 배열의 마지막 case
-                    guard let tempUsage = tempUsage else { return }
-                    usage.anchor(top: tempUsage.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 15, paddingLeft: 20, paddingBottom: 20, paddingRight: 20)
-                } else { // Usage 배열의 첫번째와 마지막이 아닌 case
-                    guard let tempUsage = tempUsage else { return }
-                    usage.anchor(top: tempUsage.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 15, paddingLeft: 20, paddingRight: 20)
-                    self.tempUsage = usage
+                if usage == usageArray.first {
+                    usage.anchor(top: usageLabel.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 15, paddingLeft: 20, paddingRight: 20)
+                } else {
+                    usage.anchor(top: self.tempUsage!.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 15, paddingLeft: 20, paddingRight: 20)
                 }
+                self.tempUsage = usage
             }
+        } else {
+            usageLabel.anchor(bottom: self.bottomAnchor, paddingBottom: 20)
+        }
+    }
+    
+    private func bottomAnchorRender() {
+        for usage in usageArray {
+            self.addSubview(usage)
+            if (usage == usageArray.first && usage == usageArray.last) || usage == usageArray.last {
+                // Usage 개수가 1개인 경우 Start Point OR 해당 context가 배열의 마지막 context일때
+                usage.anchor(bottom: self.bottomAnchor, paddingBottom: 20)
+            }
+            self.tempUsage = usage
         }
     }
     

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/WordUsageView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/WordUsageView.swift
@@ -24,8 +24,8 @@ class WordUsageView: UIView {
         usageStack.spacing = 10
         return usageStack
     }()
-    private var usageArray: [UsageContext] = []
-    private var tempUsage: UsageContext?
+    private var usageArray: [UsageContextView] = []
+    private var tempUsage: UsageContextView?
     
     // MARK: - init
     override init(frame: CGRect) {
@@ -41,8 +41,8 @@ class WordUsageView: UIView {
     
     private func dataSetting() {
         // MARK: 아래 두 데이터는 뷰를 보기위해 가상의 데이터를 만들어주었다. 추후 데이터 세팅과 불러오는데 쓰일 예정
-        let usageExample = UsageContext()
-        let usageExample2 = UsageContext()
+        let usageExample = UsageContextView()
+        let usageExample2 = UsageContextView()
         usageArray = [usageExample, usageExample2]
         usageStack.addArrangedSubview(usageLabel)
         for usage in usageArray {

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/WordUsageView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/WordUsageView.swift
@@ -1,0 +1,75 @@
+//
+//  WordUsageView.swift
+//  KBoard
+//
+//  Created by 박성수 on 2022/07/22.
+//
+
+import UIKit
+
+class WordUsageView: UIView {
+    
+    // MARK: - property
+    private let usageLabel: UILabel = {
+        let usageLabel = UILabel()
+        usageLabel.text = "Usage"
+        usageLabel.font = .systemFont(ofSize: 16, weight: .bold)
+        return usageLabel
+    }()
+    private var usageArray: [UsageContext] = []
+    private var tempUsage: UsageContext?
+    
+    // MARK: - init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        dataSetting()
+        render()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func dataSetting() {
+        // MARK: 아래 두 데이터는 뷰를 보기위해 가상의 데이터를 만들어주었다. 추후 데이터 세팅과 불러오는데 쓰일 예정
+        let usageExample = UsageContext()
+        let usageExample2 = UsageContext()
+        self.usageArray = [usageExample, usageExample2]
+    }
+    
+    private func render() {
+        self.addSubview(usageLabel)
+        if usageArray.isEmpty { // Usage 개수가 0 인 case
+            usageLabel.anchor(top: self.topAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 20, paddingLeft: 20, paddingBottom: 20, paddingRight: 20)
+        } else {
+            usageLabel.anchor(top: self.topAnchor, left: self.leftAnchor, paddingTop: 20, paddingLeft: 20)
+            for usage in usageArray {
+                self.addSubview(usage)
+                if usage == usageArray.first && usage != usageArray.last { // Usage 개수가 1개가 아닌 경우 Start Point
+                    usage.anchor(top: usageLabel.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 10, paddingLeft: 20, paddingRight: 20)
+                    tempUsage = usage
+                } else if usage == usageArray.first && usage == usageArray.last { // Usage 개수가 1개인 경우 Start Point
+                    usage.anchor(top: usageLabel.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 15, paddingLeft: 20, paddingBottom: 20, paddingRight: 20)
+                } else if usage == usageArray.last { // Usage 배열의 마지막 case
+                    guard let tempUsage = tempUsage else { return }
+                    usage.anchor(top: tempUsage.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 15, paddingLeft: 20, paddingBottom: 20, paddingRight: 20)
+                } else { // Usage 배열의 첫번째와 마지막이 아닌 case
+                    guard let tempUsage = tempUsage else { return }
+                    usage.anchor(top: tempUsage.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 15, paddingLeft: 20, paddingRight: 20)
+                    self.tempUsage = usage
+                }
+            }
+        }
+    }
+    
+    private func configureUI() {
+        self.backgroundColor = .systemBackground
+        self.layer.cornerRadius = 15
+        self.layer.masksToBounds = false
+        self.layer.shadowRadius = 5
+        self.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
+        self.layer.shadowOpacity = 0.2
+    }
+    
+}


### PR DESCRIPTION
## 개요
내용:
WordDetailView의 중간부분과 하단부분인 Usage View, Related words View UI를 완성

### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
  - [X] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (프로젝트 코드 변경 없음)

### 반영 브랜치
feat/11-wordDetailUsageRelatedUI -> develop

<br/>

## 작업사항 
### 작업 사항
- 동적으로 길이에 따라 카드뷰의 크기가 달라질 수 있도록 만들어 줌

### 테스트 결과 (스크린샷, GIF)

<img src="https://user-images.githubusercontent.com/72736657/180904458-dd3d9fea-41cf-4c88-8832-2c18c21f9db8.png" width= 250>

<br/>

## 그외
### 리뷰 포인트 
- 뷰가 올바르게 그려졌나요
- 뷰 위에 뷰를 올려주며 그리는게 좋은 방식인지

### 진행 예정 사항
- [ ] 페이지 ScrollViw가 구현되어야 한다.
- [ ] 즐겨찾기 버튼 클릭시, 카테고리를 선택할 수 있는 창이 나와야 한다.

## Checklist

- [X] 올바른 branch에 merge 하시는 건가요?
- [X] coding convention 맞추었나요?
- [X] Are there any changes not related to PR?
