### PR TITLE
Merge: Feat: "WordDetailView cardShadow() 만듬"

### DIFF
--- a/KBoard/KBoard/Utils/Extension/View+Extension.swift
+++ b/KBoard/KBoard/Utils/Extension/View+Extension.swift
@@ -79,3 +79,15 @@ extension UIView {
     }
 
 }
+
+extension UIView {
+    func cardShadow() {
+        self.backgroundColor = .systemBackground
+        self.layer.cornerRadius = 15
+        self.layer.masksToBounds = false
+        self.layer.shadowRadius = 5
+        self.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
+        self.layer.shadowOpacity = 0.2
+        
+    }
+}

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/RelatedWordsView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/RelatedWordsView.swift
@@ -91,12 +91,7 @@ class RelatedWordsView: UIView {
     }
     
     private func configureUI() {
-        self.backgroundColor = .systemBackground
-        self.layer.cornerRadius = 15
-        self.layer.masksToBounds = false
-        self.layer.shadowRadius = 5
-        self.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
-        self.layer.shadowOpacity = 0.2
+        self.cardShadow()
     }
     
     // REF: https://stackoverflow.com/a/60588546/19350352

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/WordDescriptionView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/WordDescriptionView.swift
@@ -82,12 +82,7 @@ class WordDescriptionView: UIView {
     }
     
     private func configureUI() {
-        self.backgroundColor = .systemBackground
-        self.layer.cornerRadius = 15
-        self.layer.masksToBounds = false
-        self.layer.shadowRadius = 5
-        self.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
-        self.layer.shadowOpacity = 0.2
+        self.cardShadow()
         
     }
 

--- a/KBoard/KBoard/View/WordDetailViewUIComponent/WordUsageView.swift
+++ b/KBoard/KBoard/View/WordDetailViewUIComponent/WordUsageView.swift
@@ -56,12 +56,7 @@ class WordUsageView: UIView {
     }
     
     private func configureUI() {
-        self.backgroundColor = .systemBackground
-        self.layer.cornerRadius = 15
-        self.layer.masksToBounds = false
-        self.layer.shadowRadius = 5
-        self.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
-        self.layer.shadowOpacity = 0.2
+        self.cardShadow()
     }
     
 }


### PR DESCRIPTION
WordDetailView에서 항상 쓰이는 뒷배경 shadow extension으로 빼줌

Related to: #16

## 개요
내용: WordDetailView의 카드뷰 뒷 배경의 공통된 shadow들 extension으로 빼줌

### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
  - [X] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (프로젝트 코드 변경 없음)

### 반영 브랜치
feat/16-detailViewShadowExtension -> develop

<br/>

### 테스트 결과 (스크린샷, GIF)

<img src="https://user-images.githubusercontent.com/72736657/180943902-13919ff8-b810-4a38-a75f-e36e84c336a1.png" width= 250>


<br/>

## 그외
### 리뷰 포인트 
- 위에 있는 extension은 anchor만을 위한 extension으로 만들어주기 위해 밑에 만들어 주었습니다. 괜찮을까요?

## Checklist

- [X] 올바른 branch에 merge 하시는 건가요?
- [X] coding convention 맞추었나요?
- [X] Are there any changes not related to PR?
