### PR TITLE
Merge: #45 K-pop Slang - 상단 헤더 바 UI 제작

### DIFF
--- a/KBoard/KBoard.xcodeproj/project.pbxproj
+++ b/KBoard/KBoard.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		3F24E869288FA7EA0092CEC7 /* WordModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F24E868288FA7EA0092CEC7 /* WordModel.swift */; };
 		3FCDE7622890691200C936D9 /* WordCategoryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FCDE7612890691200C936D9 /* WordCategoryListView.swift */; };
 		3FCDE7642890694A00C936D9 /* CollectionCustomCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FCDE7632890694A00C936D9 /* CollectionCustomCell.swift */; };
+		3FCDE76628916FFE00C936D9 /* DictionaryHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FCDE76528916FFE00C936D9 /* DictionaryHeaderView.swift */; };
+		3FCDE7682891707600C936D9 /* UpperHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FCDE7672891707600C936D9 /* UpperHeaderView.swift */; };
 		791636D22890E507003E8CB6 /* CategoryCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791636D12890E507003E8CB6 /* CategoryCollectionHeaderView.swift */; };
 		791636D42890E559003E8CB6 /* CategoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791636D32890E559003E8CB6 /* CategoryCollectionViewCell.swift */; };
 		79318CB4287E539A003B27D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79318CB3287E539A003B27D9 /* AppDelegate.swift */; };
@@ -72,6 +74,8 @@
 		3F24E868288FA7EA0092CEC7 /* WordModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordModel.swift; sourceTree = "<group>"; };
 		3FCDE7612890691200C936D9 /* WordCategoryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordCategoryListView.swift; sourceTree = "<group>"; };
 		3FCDE7632890694A00C936D9 /* CollectionCustomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionCustomCell.swift; sourceTree = "<group>"; };
+		3FCDE76528916FFE00C936D9 /* DictionaryHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryHeaderView.swift; sourceTree = "<group>"; };
+		3FCDE7672891707600C936D9 /* UpperHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpperHeaderView.swift; sourceTree = "<group>"; };
 		791636D12890E507003E8CB6 /* CategoryCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCollectionHeaderView.swift; sourceTree = "<group>"; };
 		791636D32890E559003E8CB6 /* CategoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		79318CB0287E539A003B27D9 /* KBoard.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KBoard.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -128,6 +132,8 @@
 				3F24E81D288D1B1B0092CEC7 /* WordCustomCell.swift */,
 				3FCDE7612890691200C936D9 /* WordCategoryListView.swift */,
 				3FCDE7632890694A00C936D9 /* CollectionCustomCell.swift */,
+				3FCDE76528916FFE00C936D9 /* DictionaryHeaderView.swift */,
+				3FCDE7672891707600C936D9 /* UpperHeaderView.swift */,
 			);
 			path = DictionaryViewUIComponent;
 			sourceTree = "<group>";
@@ -433,6 +439,7 @@
 				79E659CB288FC3BD00FD54B6 /* CategoryViewController.swift in Sources */,
 				3F24E81C288D15AB0092CEC7 /* WordListView.swift in Sources */,
 				7B301F50288FA93400E20AEB /* CategoryListViewController.swift in Sources */,
+				3FCDE76628916FFE00C936D9 /* DictionaryHeaderView.swift in Sources */,
 				DF0445CD288FA872004AD0FF /* RelatedWordsView.swift in Sources */,
 				7934B4EC2880210D00CF38E9 /* Constants.swift in Sources */,
 				DF0445CC288FA872004AD0FF /* UsageContextView.swift in Sources */,
@@ -449,6 +456,7 @@
 				3F24E81A288D14E20092CEC7 /* DictionaryViewController.swift in Sources */,
 				DF0445CE288FA872004AD0FF /* WordUsageView.swift in Sources */,
 				791636D22890E507003E8CB6 /* CategoryCollectionHeaderView.swift in Sources */,
+				3FCDE7682891707600C936D9 /* UpperHeaderView.swift in Sources */,
 				3FCDE7622890691200C936D9 /* WordCategoryListView.swift in Sources */,
 				79318CB6287E539A003B27D9 /* SceneDelegate.swift in Sources */,
 				7B301F54288FA9CA00E20AEB /* AddNewCategory.swift in Sources */,

--- a/KBoard/KBoard/Controller/KPopSlang/DictionaryViewController.swift
+++ b/KBoard/KBoard/Controller/KPopSlang/DictionaryViewController.swift
@@ -9,27 +9,82 @@ import UIKit
 
 class DictionaryViewController: UIViewController {
     
-    private let wordListView = WordListView()
-    private let wordCategoryListView = WordCategoryListView()
+    private let dictionaryHeaderView = DictionaryHeaderView()
+    var tableView = UITableView()
+    var headerViewTopConstraint: NSLayoutConstraint?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         render()
         configureUI()
-        
+        setupTableView()
     }
     
     private func render() {
-        view.addSubview(wordListView)
-        view.addSubview(wordCategoryListView)
         
-        wordListView.anchor(top: wordCategoryListView.bottomAnchor, left: view.leftAnchor, bottom: view.safeAreaLayoutGuide.bottomAnchor, right: view.rightAnchor, paddingTop: 10, paddingLeft: 0, paddingBottom: 0, paddingRight: 0)
+        view.addSubview(dictionaryHeaderView)
+        view.addSubview(tableView)
         
-        wordCategoryListView.anchor(top: view.safeAreaLayoutGuide.topAnchor, left: view.leftAnchor, bottom: wordListView.topAnchor, right: view.rightAnchor, paddingTop: 0, paddingLeft: 0, paddingBottom: 10, paddingRight: 0, height: 40)
+        dictionaryHeaderView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        
+        headerViewTopConstraint = dictionaryHeaderView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+
+        NSLayoutConstraint.activate([
+        
+            headerViewTopConstraint!,
+            dictionaryHeaderView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            dictionaryHeaderView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            
+            tableView.topAnchor.constraint(equalTo: dictionaryHeaderView.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+
     }
     
     private func configureUI() {
         view.backgroundColor = .systemBackground
         
     }
+}
+
+
+extension DictionaryViewController: UITableViewDelegate, UITableViewDataSource {
+    
+    func setupTableView() {
+
+        tableView.delegate = self
+        tableView.dataSource = self
+        
+        tableView.separatorStyle = .none // cell line 없애기
+        tableView.register(WordCustomCell.self , forCellReuseIdentifier: WordCustomCell.tableCellId)
+        
+    }
+
+    // 행의 개수를 설정하는 메소드
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return Word.words.count
+    }
+
+    // 셀을 만드는 메소드
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: WordCustomCell.tableCellId, for: indexPath) as! WordCustomCell
+//        cell.backgroundColor = UIColor(rgb: 0xF7F8FA)
+        cell.selectionStyle = .none
+        cell.HangleName.text = Word.words[indexPath.row].hangleName
+        cell.EnglishName.text = Word.words[indexPath.row].englishName
+
+        return cell
+    }
+    
+    // DetailView로 들어가기
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath){
+        let word = Word.words[indexPath.row]
+        let vc = WordDetailViewController()
+        navigationController?.pushViewController(vc, animated: true)
+    }
+    
 }

--- a/KBoard/KBoard/SupportFiles/SceneDelegate.swift
+++ b/KBoard/KBoard/SupportFiles/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        let nav = UINavigationController(rootViewController: CategoryViewController())
+        let nav = UINavigationController(rootViewController: DictionaryViewController()) // CategoryViewController
         window?.rootViewController = nav
         window?.makeKeyAndVisible()
     }

--- a/KBoard/KBoard/SupportFiles/SceneDelegate.swift
+++ b/KBoard/KBoard/SupportFiles/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        let nav = UINavigationController(rootViewController: CategoryViewController()) 
+        let nav = UINavigationController(rootViewController: CategoryViewController())
         window?.rootViewController = nav
         window?.makeKeyAndVisible()
     }

--- a/KBoard/KBoard/SupportFiles/SceneDelegate.swift
+++ b/KBoard/KBoard/SupportFiles/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        let nav = UINavigationController(rootViewController: DictionaryViewController()) // CategoryViewController
+        let nav = UINavigationController(rootViewController: CategoryViewController()) 
         window?.rootViewController = nav
         window?.makeKeyAndVisible()
     }

--- a/KBoard/KBoard/View/KPopSlang/DictionaryViewUIComponent/DictionaryHeaderView.swift
+++ b/KBoard/KBoard/View/KPopSlang/DictionaryViewUIComponent/DictionaryHeaderView.swift
@@ -1,0 +1,47 @@
+//
+//  DictionaryHeaderView.swift
+//  KBoard
+//
+//  Created by ParkJunHyuk on 2022/07/27.
+//
+
+import UIKit
+
+class DictionaryHeaderView: UIView {
+    private let wordCategoryListView = WordCategoryListView()
+    
+    let upperHeaderView  = UpperHeaderView()
+    
+    private let searchBar = UISearchBar()
+    
+    override init(frame: CGRect) {
+             super.init(frame: frame)
+             render()
+             configureUI()
+    }
+
+     required init?(coder: NSCoder) {
+         fatalError("init(coder:) has not been implemented")
+     }
+    
+    private func render() {
+        
+        self.addSubview(upperHeaderView)
+        upperHeaderView.anchor(top: self.safeAreaLayoutGuide.topAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 0, paddingLeft: 0, paddingRight: 0)
+        
+        self.addSubview(searchBar)
+        searchBar.anchor(top: upperHeaderView.bottomAnchor, left: self.leftAnchor, right: self.rightAnchor, paddingTop: 0, paddingLeft: 0, paddingRight: 0)
+        
+        searchBar.isTranslucent = false
+        searchBar.placeholder = "Search the phrase"
+        
+        self.addSubview(wordCategoryListView)
+        wordCategoryListView.anchor(top: searchBar.bottomAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 20, paddingLeft: 0, paddingBottom: 20, paddingRight: 0)
+        
+    }
+    
+    private func configureUI() {
+         self.backgroundColor = .systemBackground
+    }
+    
+}

--- a/KBoard/KBoard/View/KPopSlang/DictionaryViewUIComponent/UpperHeaderView.swift
+++ b/KBoard/KBoard/View/KPopSlang/DictionaryViewUIComponent/UpperHeaderView.swift
@@ -1,0 +1,38 @@
+//
+//  UpperHeaderView.swift
+//  KBoard
+//
+//  Created by ParkJunHyuk on 2022/07/27.
+//
+
+import UIKit
+
+class UpperHeaderView: UIView {
+    
+    lazy var largeTitle: UILabel = {
+        let label = UILabel()
+        label.text = "K-POP Slang"
+        label.font = UIFont.boldSystemFont(ofSize: 34)
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+             super.init(frame: frame)
+             render()
+             configureUI()
+    }
+
+     required init?(coder: NSCoder) {
+         fatalError("init(coder:) has not been implemented")
+     }
+    
+    private func render() {
+        
+        self.addSubview(largeTitle)
+        largeTitle.anchor(top: self.safeAreaLayoutGuide.topAnchor, left: self.leftAnchor, bottom: self.bottomAnchor, right: self.rightAnchor, paddingTop: 0, paddingLeft: Constants.cellHorizontalInterval, paddingBottom: 0 , paddingRight: Constants.cellHorizontalInterval, height: 50)
+    }
+    
+    private func configureUI() {
+         self.backgroundColor = .systemBackground
+    }
+}


### PR DESCRIPTION
## 개요
내용: 스크롤 시 사라직 UpperHeaderView 와 UpperHeader 와 SearchBar CategoryListView 가 포함된 DictionaryHeaderView 를 custom 했습니다

### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
  - [X] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (프로젝트 코드 변경 없음)

### 반영 브랜치
feat/#45-DictionaryHeaderView -> develop

<br/>

## 작업사항 
### 작업 사항
- 전체 Header 인 `DictionaryHeaderView` 구현 ( `UpperHeaderView,` `SearchBar,` `categoryListView` 포함 )
- 스크롤시 사라질 `UpperHeaderView` 구현 ( 상단 title, UILabel )
- `DictionaryViewController` 에 구현

### 테스트 결과 (스크린샷, GIF)

<img width="500" alt="스샷" src="https://user-images.githubusercontent.com/45564605/181398685-daef91eb-8085-4dd2-b135-a07cd856f43e.png">

<br/>

## 그외
### 리뷰 포인트 
ex) 리뷰받고 싶은 내용, 고민한 내용  등에 대해 적어주세요
- code 의 가독성에 대해 많은 얘기가 있으면 좋겠습니다!
- 변수, 함수 명 등 직관적으로 이름이 지어졌는지 확인 부탁드립니다.
- 스크롤 시 `DictionaryHeaderView` 의 변화를 위해 `extension anchor` 를 사용하지 못했습니다!

### 진행 예정 사항
ex) 작업 진행 예정사항 및 개선하고 싶은 내용이 있다면 추가 해주세요 
- [ ] tableView 를 스크롤 시 상단 headerView 중 `UpperHeaderView` 사라지게 하기
- [ ] `DictionaryHeaderView` 중 남아있는 Component 는 상단에 고정 시키기 

## Checklist

- [X] 올바른 branch에 merge 하시는 건가요?
- [X] coding convention 맞추었나요?
- [X] Are there any changes not related to PR?
