### PR TITLE
Merge: #47 K-pop Slang - Sticky Header View 구현

### DIFF
--- a/KBoard/KBoard/Controller/KPopSlang/DictionaryViewController.swift
+++ b/KBoard/KBoard/Controller/KPopSlang/DictionaryViewController.swift
@@ -42,15 +42,12 @@ class DictionaryViewController: UIViewController {
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
-
     }
     
     private func configureUI() {
         view.backgroundColor = .systemBackground
-        
     }
 }
-
 
 extension DictionaryViewController: UITableViewDelegate, UITableViewDataSource {
     
@@ -62,6 +59,25 @@ extension DictionaryViewController: UITableViewDelegate, UITableViewDataSource {
         tableView.separatorStyle = .none // cell line 없애기
         tableView.register(WordCustomCell.self , forCellReuseIdentifier: WordCustomCell.tableCellId)
         
+    }
+    
+    // TableView scroll 시 실행되는 메소드
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let y = scrollView.contentOffset.y // Y 축으로 스크롤 되는 크기
+
+        let swipingDown = y <= 0 // 아래로 스크롤 됐다는 상태 변수
+        let shouldSnap = y > 60 // UpperHeaderView 높이 + padding
+        let headerHeight = 170 // 전체 HeaderView 높이
+        
+        UIView.animate(withDuration: 0.3){
+            self.dictionaryHeaderView.upperHeaderView.alpha = swipingDown ? 1.0 : 0.0
+        }
+
+        UIViewPropertyAnimator.runningPropertyAnimator(withDuration: 0.3, delay: 0, options: [], animations: {
+            self.headerViewTopConstraint?.constant = CGFloat(shouldSnap ? -headerHeight : 0)
+            self.view.layoutIfNeeded()
+        })
+
     }
 
     // 행의 개수를 설정하는 메소드


### PR DESCRIPTION
## 개요
내용: 아래로 스크롤시 Title 은 사라지고 SearchBar 와 Category List 는 존재하는 형태의 Sticky Header View 구현

### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
  - [X] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (프로젝트 코드 변경 없음)

### 반영 브랜치
feat/#47-UpperHeaderViewAnimation-> develop

<br/>

## 작업사항 
### 작업 사항
- Header 를 title 이 사라질 UpperHeader 와 기존 `SearchBar`, `Category List` 로 나누기
- `TableView`를 스크롤 시 움직이는 Y 값에 따라서 `UpperHeaderView` 가리기
- `SearchBar`, `Category List` 는 `UpperHeaderView` 가 사라졌기 때문에 위로 고정

### References
ex) 작업시 참고한 자료가 있다면 추가해주세요!
  - [Sticky header Blog](https://iamcho2.github.io/2020/11/02/uitableview-sticky-header)
  - [Sticky header Youtube](https://www.youtube.com/watch?v=gt3iq0Q7ujY&t=1868s)

### 테스트 결과 (스크린샷, GIF)
<img width="500" alt="스샷" src="https://user-images.githubusercontent.com/45564605/181407274-e5cd36b0-5838-4b5b-bcae-f3fd0f4b98dd.gif">


<br/>

## 그외
### 리뷰 포인트 
- Sticky Header 가 잘 작동하는지 확인 부탁드립니다!
- 각 Component 가 알맞는 자리에 있는지 확인 부탁드립니다!
- code 의 가독성에 대해 많은 얘기가 있으면 좋겠습니다!
- 변수, 함수 명 등 직관적으로 이름이 지어졌는지 확인 부탁드립니다.

### 진행 예정 사항
- [ ] 디자인이 완료 되면 디자인 변경 예정
- [ ] 좀더 부드러운 Sticky header animation 구현 예정

## Checklist

- [X] 올바른 branch에 merge 하시는 건가요?
- [X] coding convention 맞추었나요?
- [X] Are there any changes not related to PR?
